### PR TITLE
IVI-1170 add 'EXPIRED' to OrderState(s)

### DIFF
--- a/common/order/definition.proto
+++ b/common/order/definition.proto
@@ -13,4 +13,5 @@ enum OrderState {
   DECLINED = 4;
   FAILED = 5;
   PAID = 6;
+  EXPIRED = 7;
 }


### PR DESCRIPTION
Contingent for ivi-engine [PR #335](https://github.com/MythicalGames/ivi-engine/pull/335)
Adds a new OrderState to be used as the status for timed-out orders (orders taking more that 15 minutes to process)